### PR TITLE
Remove all references to 'isNewVersionCompatible'

### DIFF
--- a/src/impl/pool/scratchorg/poolCreateImpl.ts
+++ b/src/impl/pool/scratchorg/poolCreateImpl.ts
@@ -333,21 +333,21 @@ export default class PoolCreateImpl {
 
             await ScratchOrgUtils.getScratchOrgRecordId(poolUser.scratchOrgs, this.hubOrg);
 
-            if (ScratchOrgUtils.isNewVersionCompatible) {
-                let scratchOrgInprogress = [];
 
-                poolUser.scratchOrgs.forEach((scratchOrg) => {
-                    scratchOrgInprogress.push({
-                        Id: scratchOrg.recordId,
-                        Pooltag__c: this.poolConfig.pool.tag,
-                        Allocation_status__c: 'In Progress',
-                    });
+            let scratchOrgInprogress = [];
+
+            poolUser.scratchOrgs.forEach((scratchOrg) => {
+                scratchOrgInprogress.push({
+                    Id: scratchOrg.recordId,
+                    Pooltag__c: this.poolConfig.pool.tag,
+                    Allocation_status__c: 'In Progress',
                 });
+            });
 
-                if (scratchOrgInprogress.length > 0) {
-                    //set pool tag
-                    await ScratchOrgUtils.setScratchOrgInfo(scratchOrgInprogress, this.hubOrg);
-                }
+            if (scratchOrgInprogress.length > 0) {
+                //set pool tag
+                await ScratchOrgUtils.setScratchOrgInfo(scratchOrgInprogress, this.hubOrg);
+
             }
         }
     }

--- a/src/impl/pool/scratchorg/poolListImpl.ts
+++ b/src/impl/pool/scratchorg/poolListImpl.ts
@@ -40,8 +40,8 @@ export default class PoolListImpl {
                 if (element.Allocation_status__c === 'Assigned') {
                     soDetail.status = 'In use';
                 } else if (
-                    (ScratchOrgUtils.isNewVersionCompatible && element.Allocation_status__c === 'Available') ||
-                    (!ScratchOrgUtils.isNewVersionCompatible && !element.Allocation_status__c)
+                    (element.Allocation_status__c === 'Available') ||
+                    (!element.Allocation_status__c)
                 ) {
                     soDetail.status = 'Available';
                 } else {

--- a/src/impl/pool/scratchorg/poolListImpl.ts
+++ b/src/impl/pool/scratchorg/poolListImpl.ts
@@ -39,10 +39,7 @@ export default class PoolListImpl {
                 soDetail.expiryDate = element.ExpirationDate;
                 if (element.Allocation_status__c === 'Assigned') {
                     soDetail.status = 'In use';
-                } else if (
-                    (element.Allocation_status__c === 'Available') ||
-                    (!element.Allocation_status__c)
-                ) {
+                } else if (element.Allocation_status__c === 'Available') {
                     soDetail.status = 'Available';
                 } else {
                     soDetail.status = 'Provisioning in progress';

--- a/src/utils/scratchOrgUtils.ts
+++ b/src/utils/scratchOrgUtils.ts
@@ -10,7 +10,6 @@ const child_process = require('child_process');
 
 const ORDER_BY_FILTER = ' ORDER BY CreatedDate ASC';
 export default class ScratchOrgUtils {
-    public static isNewVersionCompatible = false;
     private static sfdxAuthUrlFieldExists = false;
 
     public static async getScratchOrgLimits(hubOrg: Org, apiversion: string) {


### PR DESCRIPTION
## Summary of changes
Some hanging references to isNewVersionCompatible were causing ScratchOrgs to be stuck 'In Progress' 

## Checklist
- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [ ] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) required?
- [x] Tested changes? 

## Testing 
Tested against all pool commands 
