### PR TITLE
fix(buildpackage): add version tag to publish command

### DIFF
--- a/.github/workflows/buildPackage.yml
+++ b/.github/workflows/buildPackage.yml
@@ -41,6 +41,6 @@ jobs:
         run: |
             npm install
             
-      - run: npm publish --access public
+      - run: npm publish --access public --tag ${{ inputs.version }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm-token}}


### PR DESCRIPTION
## Summary of changes
Version tag was missing from the build workflow, all builds were being tagged as latest on npm 

## Checklist
- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [ ] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) required?
- [ ] Tested changes? 
