### PR TITLE
fix(package.json):require download of exact node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "request": "^2.88.2",
         "request-promise-native": "^1.0.9",
         "simple-git": "3.5.0",
-        "ts-node": "^9.1.1",
+        "ts-node": "9.1.1",
         "tslib": "2.1.0",
         "unzip-stream": "0.3.1",
         "unzipper": "0.10.11",
@@ -56,7 +56,7 @@
         "@types/fs-extra": "^9.0.11",
         "@types/jsforce": "^1.9.23",
         "@types/mocha": "^9.1.0",
-        "@types/node": "^14.14.7",
+        "@types/node": "14.14.7",
         "@types/pino": "^6.3.7",
         "@types/request-promise": "^4.1.47",
         "@types/rimraf": "^3.0.0",
@@ -72,7 +72,7 @@
         "pretty-quick": "^3.1.0",
         "rimraf": "^3.0.2",
         "sinon": "^10.0.0",
-        "typescript": "^4.5.4"
+        "typescript": "4.5.4"
     },
     "engines": {
         "node": ">=8.0.0"


### PR DESCRIPTION
## Summary of changes
fix(package.json): force download of exact node versions required to fix below linking issue: 

"Error: Debug Failure. False expression: Non-string value passed to `ts.resolveTypeReferenceDirective`, likely by a wrapping package working with an outdated `resolveTypeReferenceDirectives` signature. This is probably not a problem in
TS itself."


## Checklist
- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) required?
- [x] Tested changes? 

Tested locally and via PR smoke test
PR test: https://github.com/dxatscale/sfpowerkit/runs/7717602766?check_suite_focus=true  
