### PR TITLE
(ci) Add --dist-tag to npm publish command

### DIFF
--- a/.github/workflows/buildPackage.yml
+++ b/.github/workflows/buildPackage.yml
@@ -41,6 +41,6 @@ jobs:
         run: |
             npm install
             
-      - run: npm publish --access public --tag ${{ inputs.version }}
+      - run: npm publish --access public --dist-tag ${{ inputs.version }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm-token}}


### PR DESCRIPTION
## Summary of changes
As we were unable to publish over an existing npm publish using --tag we are using --dist-tag in the build pipeline instead. 

## Checklist
- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) required?
- [x] Tested changes? 
