### PR TITLE
fix(scratchorgutils): set Scratch Org alias

### DIFF
--- a/src/utils/scratchOrgUtils.ts
+++ b/src/utils/scratchOrgUtils.ts
@@ -100,7 +100,7 @@ export default class ScratchOrgUtils {
         SFPLogger.log(JSON.stringify(result), LoggerLevel.TRACE);
 
         let scratchOrg: ScratchOrg = {
-            alias: resultObject.result.alias,
+            alias: alias_prefix ? `${alias_prefix}${id}` : `SO${id}`,
             orgId: resultObject.result.orgId,
             username: resultObject.result.username,
             signupEmail: adminEmail ? adminEmail : '',


### PR DESCRIPTION
## Summary of changes
Fix for issue #726 force:org:create no longer returns the scratch org alias, as such we are setting the alias after the
creation


## Checklist
- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) required?
- [x] Tested changes? 
