### PR TITLE
Remove typo from help command for sfdx sfpowerkit:source:profile:merg…

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ OPTIONS
 
 EXAMPLES
   $ sfdx sfpowerkit:source:profile:merge -u sandbox
-  $ sfdx sfpowerkit:source:profile:merge -f force-app -n "My Profile" -r -u sandbox
+  $ sfdx sfpowerkit:source:profile:merge -f force-app -n "My Profile" -u sandbox
   $ sfdx sfpowerkit:source:profile:merge -f "module1, module2, module3" -n "My Profile1, My profile2"  -u sandbox
 ```
 

--- a/src/commands/sfpowerkit/source/profile/merge.ts
+++ b/src/commands/sfpowerkit/source/profile/merge.ts
@@ -19,7 +19,7 @@ export default class Merge extends SfpowerkitCommand {
 
     public static examples = [
         `$ sfdx sfpowerkit:source:profile:merge -u sandbox`,
-        `$ sfdx sfpowerkit:source:profile:merge -f force-app -n "My Profile" -r -u sandbox`,
+        `$ sfdx sfpowerkit:source:profile:merge -f force-app -n "My Profile" -u sandbox`,
         `$ sfdx sfpowerkit:source:profile:merge -f "module1, module2, module3" -n "My Profile1, My profile2"  -u sandbox`,
     ];
 


### PR DESCRIPTION
## Summary of changes
- Remove '-r' from help command for sfdx sfpowerkit:source:profile:merge
- remove '-r' from Readme file for sfdx sfpowerkit:source:profile:merge


## Checklist
- [ ] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [ ] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) required?
- [ ] Tested changes? 
