### PR TITLE
[#744]-Getting text 'Config folder does not exists, Creating Folder' with --json param

### DIFF
--- a/src/sfpowerkitCommand.ts
+++ b/src/sfpowerkitCommand.ts
@@ -22,6 +22,9 @@ export default abstract class SfpowerkitCommand extends SfdxCommand {
      */
     async run(): Promise<any> {
         Sfpowerkit.setLogLevel(this.flags.loglevel, this.flags.json);
+        if(this.flags.json) {
+            SFPLogger.disableLogs();
+        }
         Sfpowerkit.resetCache();
 
         // Always enable color by default
@@ -36,8 +39,6 @@ export default abstract class SfpowerkitCommand extends SfdxCommand {
 
         if (!this.flags.json) {
             this.sfpowerkitHeader();
-        }else{
-            SFPLogger.disableLogs();
         }
 
         return this.execute();


### PR DESCRIPTION
## Summary of changes
Updated file sfPowerkitCommand.ts
The json param needs to be checked before resetting cache for disabling logs



## Checklist
- [ ✅ ] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [ ✅ ] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) required?
- [ ✅ ] Tested changes? 
