### PR TITLE
fix(metadataRetriever): get tabs with tooling api

### DIFF
--- a/src/impl/metadata/retriever/metadataRetriever.ts
+++ b/src/impl/metadata/retriever/metadataRetriever.ts
@@ -80,7 +80,7 @@ export default class MetadataRetriever {
         let query = `SELECT Id,  Name, SobjectName, DurableId, IsCustom, Label FROM TabDefinition`;
 
         let queryUtil = new QueryExecutor(this._conn);
-        let items = await queryUtil.executeQuery(query, false);
+        let items = await queryUtil.executeQuery(query, true);
 
         if (items === undefined || items === null) {
             items = [];


### PR DESCRIPTION
This fixes #737 and #738

## Summary of changes

It looks like the Tooling API returns more `TabDefinition`s records (and therefore more accurate) than the SOAP API.
These are the ones which are mentioned to be missing in #737.
They are now included in the `sfpowerkit:source:profile:retrieval` and retained in the `sfpowerkit:source:profile:reconcile` command.

Here is the diff from the output of running

`sfdx force:data:soql:query -q "SELECT Name FROM TabDefinition"`
vs.
`sfdx force:data:soql:query -q "SELECT Name FROM TabDefinition" --usetoolingapi`

```diff
--- tab-definitions-soap.csv
+++ tab-definitions-tooling.csv
@@ -7,11 +7,17 @@
 standard-AuthorizationFormConsent
 standard-AuthorizationFormDataUse
 standard-AuthorizationFormText
+standard-Award
 standard-BackgroundOperation
+standard-Budget
+standard-BudgetAllocation
 standard-BusinessBrand
 standard-Campaign
 standard-Case
 standard-CmsAuthorHome
+standard-CmsChannel
+standard-CmsExperiences
+standard-CmsWorkspaces
 standard-CommSubscription
 standard-CommSubscriptionChannelType
 standard-CommSubscriptionConsent
@@ -20,7 +26,10 @@
 standard-ContactPointConsent
 standard-ContactPointTypeConsent
 standard-ContactRequest
+standard-ContentDocumentListViewMapping
 standard-ContentNote
+standard-ContentSearch
+standard-ContentSubscriptions
 standard-Contract
 standard-ContractLineItem
 standard-Customer
@@ -42,6 +51,8 @@
 standard-FlowOrchestrationWorkItem
 standard-Forecasting3
 standard-Idea
+standard-IdeaTheme
+standard-IdentityDocument
 standard-Image
 standard-Individual
 standard-Knowledge
@@ -54,6 +65,7 @@
 standard-LocationTrustMeasure
 standard-Macro
 standard-MobileHome
+standard-OmnichannelInventory
 standard-OnlineSalesHome
 standard-Opportunity
 standard-Order
@@ -68,7 +80,9 @@
 standard-ScheduleAppointments
 standard-Scorecard
 standard-Seller
+standard-ServiceAppointmentGroup
 standard-ServiceContract
+standard-ServiceTerritoryRelationship
 standard-SocialPersona
 standard-SocialPost
 standard-Solution
@@ -76,6 +90,11 @@
 standard-Task
 standard-Today
 standard-UserProvisioningRequest
+standard-VoiceCall
 standard-WorkOrder
+standard-WorkProcedure
+standard-WorkProcedureStep
+standard-WorkTypeExtension
+standard-Workspace
 standard-home
 standard-report
 ```

## Checklist
- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale) yes
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) required? no
- [x] Tested changes?  yes, tested the `sfpowerkit:source:profile:retrieval` and `sfpowerkit:source:profile:reconcile` commands